### PR TITLE
feat: add SaaS templates and PR-based sync workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.codex
+.last_sync.local
+sync.log

--- a/README.md
+++ b/README.md
@@ -61,13 +61,15 @@ curl -fsSL https://claude.ai/install.sh | bash
 npm install -g @openai/codex
 ```
 
-### `sync.sh` — Snapshot and push changes
+### `sync.sh` — Snapshot, branch, and open a PR
 
-Validates the repo against `origin/master`, then copies current non-sensitive dotfiles and a snapshot of installed packages into the repo, commits, and pushes. If the local branch is behind or diverged, if tracked snapshot files already have local edits, or if a secret-like value is detected in the managed files, sync stops instead of publishing.
+Validates local `master` against `origin/master`, then copies current non-sensitive dotfiles and a snapshot of installed packages into the repo. When there is a real snapshot change, `sync.sh` creates a fresh sync branch, commits there, pushes the branch, and opens a PR if `gh` is available and authenticated. If local `master` is behind or diverged, if tracked snapshot files already have local edits, if the worktree has unrelated changes, or if a secret-like value is detected in the managed files, sync stops instead of publishing.
 
 ```bash
-bash sync.sh           # sync and push
-bash sync.sh --dry-run # preview changes, no commits made
+bash sync.sh                        # sync, branch, push, and try to open a PR
+bash sync.sh --no-pr                # sync and push a branch without opening a PR
+bash sync.sh --branch-name env/wsl  # use a custom branch name
+bash sync.sh --dry-run              # preview what would happen, no changes made
 ```
 
 Two mechanisms keep sync visible even if WSL was off on the scheduled day:
@@ -77,9 +79,9 @@ Two mechanisms keep sync visible even if WSL was off on the scheduled day:
    0 9 */15 * * /bin/bash ~/repo/wsl_setup/sync.sh >> ~/repo/wsl_setup/sync.log 2>&1
    ```
 
-2. **Terminal startup reminder** — every time you open a terminal, `.zshrc` reads `.last_sync`, reminds you to run sync manually if 15+ days have passed, and warns when the local repo is behind `origin/master`. This catches the case where WSL was off when cron was supposed to fire and also nudges you to update before syncing.
+2. **Terminal startup reminder** — every time you open a terminal, `.zshrc` reads `.last_sync.local` if present and falls back to the tracked `.last_sync` baseline. It reminds you to run sync manually if 15+ days have passed, and warns when the local repo is behind `origin/master`. This catches the case where WSL was off when cron was supposed to fire and also nudges you to update before syncing.
 
-`.last_sync` is a Unix timestamp file. `sync.sh` refreshes it locally after successful no-op runs, and includes it in the commit when dotfiles or package snapshots actually change. On a fresh clone, the committed value still gives a reasonable starting point for the 15-day window.
+`.last_sync.local` is machine-local and is refreshed after successful sync runs or no-op runs. The tracked `.last_sync` remains only as a fallback baseline for fresh clones. This avoids timestamp-only merge churn between environments.
 
 To install the cron job on a new machine after cloning:
 
@@ -88,6 +90,14 @@ To install the cron job on a new machine after cloning:
 ```
 
 Sync history is logged to `sync.log`.
+
+Recommended multi-environment strategy:
+
+1. Keep `master` as the reviewed integration branch.
+2. Run `sync.sh` from a clean local `master`.
+3. Let `sync.sh` create a fresh branch and PR for that environment snapshot.
+4. Review and merge manually.
+5. Keep script/template changes in separate PRs from environment snapshot PRs.
 
 ---
 
@@ -157,7 +167,7 @@ Example output:
                     +----------------------+
                     |      sync.sh         |
                     | validate, snapshot,  |
-                    | commit, push         |
+                    | branch, PR           |
                     +----------------------+
 ```
 
@@ -212,7 +222,7 @@ set default shell to zsh
 optionally run gh auth login
   |
   v
-initialize .last_sync
+initialize .last_sync.local
   |
   v
 done
@@ -306,8 +316,9 @@ validate repo state
   |
   +--> compare HEAD vs origin/master
          - if behind: abort
+         - if ahead: abort
          - if diverged: abort
-         - if up to date / ahead: continue
+         - if up to date: continue
   |
   v
 sync dotfiles
@@ -324,18 +335,20 @@ snapshot packages
   +--> if different -> overwrite packages.txt
   |
   v
-commit/push phase
+publish phase
   |
   +--> run secret scan gate
   |
   +--> if dotfiles/packages changed:
-  |      update .last_sync
-  |      git add managed snapshots + templates + .last_sync
+  |      create fresh sync branch
+  |      update .last_sync.local
+  |      git add managed snapshots
   |      git commit
-  |      git push origin master
+  |      git push origin <sync-branch>
+  |      gh pr create (when available)
   |
   +--> else:
-         update .last_sync locally only
+         update .last_sync.local only
          no commit
          no push
   |
@@ -351,7 +364,8 @@ new shell starts
   v
 run _wsl_sync_check()
   |
-  +--> read .last_sync
+  +--> read .last_sync.local
+  +--> if missing, fall back to tracked .last_sync
   +--> compute now - last_sync
   +--> if < 15 days: do nothing
   +--> if >= 15 days:
@@ -393,7 +407,7 @@ Stored in `dotfiles/` and deployed to `~/` by `setup.sh`. Any existing file is b
 | `.gitconfig.template` | GitHub CLI credential helper + placeholders |
 | `.npmrc.template`     | baseline npm config                          |
 
-`.last_sync` is a Unix timestamp file at the repo root. `sync.sh` refreshes it on successful runs to throttle auto-sync checks, but only commits it when there is a real snapshot change to publish. That avoids timestamp-only commits while still giving fresh clones a usable baseline.
+`.last_sync.local` is the machine-local Unix timestamp used by the sync reminder. The tracked `.last_sync` remains in the repo only as a fallback baseline for fresh clones. `sync.sh` refreshes `.last_sync.local` on successful runs but does not commit it, which avoids timestamp-only conflicts across environments.
 
 ---
 

--- a/check.sh
+++ b/check.sh
@@ -77,7 +77,7 @@ check_repo_sync_status() {
     ok "Branch is up to date with $REMOTE_REF"
   elif [ "$local_head" = "$merge_base" ]; then
     warn "Branch is behind $REMOTE_REF"
-    remote_managed_changes=$(git diff --name-status "HEAD..$REMOTE_REF" -- dotfiles packages.txt .last_sync 2>/dev/null || true)
+    remote_managed_changes=$(git diff --name-status "HEAD..$REMOTE_REF" -- dotfiles packages.txt 2>/dev/null || true)
     if [ -n "$remote_managed_changes" ]; then
       echo "$remote_managed_changes" | while IFS= read -r line; do
         warn "Remote managed change: $line"
@@ -88,7 +88,7 @@ check_repo_sync_status() {
     ok "Branch is ahead of $REMOTE_REF"
   else
     warn "Branch has diverged from $REMOTE_REF"
-    remote_managed_changes=$(git diff --name-status "$merge_base..$REMOTE_REF" -- dotfiles packages.txt .last_sync 2>/dev/null || true)
+    remote_managed_changes=$(git diff --name-status "$merge_base..$REMOTE_REF" -- dotfiles packages.txt 2>/dev/null || true)
     if [ -n "$remote_managed_changes" ]; then
       echo "$remote_managed_changes" | while IFS= read -r line; do
         warn "Remote managed change: $line"

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -120,7 +120,8 @@ export PATH="$HOME/.local/bin:$PATH"
 # Remind when sync is due; publishing remains a manual action.
 _wsl_sync_check() {
   local sync_script="$HOME/repo/wsl_setup/sync.sh"
-  local stamp_file="$HOME/repo/wsl_setup/.last_sync"
+  local local_stamp_file="$HOME/repo/wsl_setup/.last_sync.local"
+  local tracked_stamp_file="$HOME/repo/wsl_setup/.last_sync"
   local repo_dir="$HOME/repo/wsl_setup"
   local remote_ref="origin/master"
   local interval=$((15 * 86400)) # 15 days in seconds
@@ -129,7 +130,11 @@ _wsl_sync_check() {
 
   local now=$(date +%s)
   local last=0
-  [[ -f "$stamp_file" ]] && last=$(cat "$stamp_file")
+  if [[ -f "$local_stamp_file" ]]; then
+    last=$(cat "$local_stamp_file")
+  elif [[ -f "$tracked_stamp_file" ]]; then
+    last=$(cat "$tracked_stamp_file")
+  fi
 
   if (( now - last >= interval )); then
     echo "[wsl-sync] 15 days since last sync — run: bash ~/repo/wsl_setup/sync.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,7 @@
 #   7. Sets zsh as the default shell
 #   8. Prompts to authenticate GitHub CLI
 #   9. Installs Python security audit tools via pipx
+#  10. Initializes the local sync reminder timestamp
 
 set -euo pipefail
 
@@ -258,8 +259,8 @@ fi
 
 # ── 12. Initialise sync timestamp ────────────────────────────────────────────
 step "Initialising sync timestamp"
-run bash -c "date +%s > \"$SCRIPT_DIR/.last_sync\""
-info ".last_sync created — first auto-sync will run in 15 days"
+run bash -c "date +%s > \"$SCRIPT_DIR/.last_sync.local\""
+info ".last_sync.local created — first auto-sync will run in 15 days"
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 echo ""

--- a/sync.sh
+++ b/sync.sh
@@ -1,17 +1,42 @@
 #!/usr/bin/env bash
-# sync.sh — Snapshots current dotfiles + installed packages into the repo and pushes.
+# sync.sh — Snapshots current dotfiles + installed packages into a fresh branch and opens a PR.
 # Designed to run via cron every 15 days, or manually at any time.
-# Usage: bash sync.sh [--dry-run]
+# Usage: bash sync.sh [--dry-run] [--no-pr] [--branch-name NAME]
 
 set -euo pipefail
 
 DRY_RUN=false
-[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+OPEN_PR=true
+BRANCH_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --no-pr)
+      OPEN_PR=false
+      shift
+      ;;
+    --branch-name)
+      BRANCH_NAME="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="$SCRIPT_DIR/dotfiles"
 LOG_FILE="$SCRIPT_DIR/sync.log"
-REMOTE_REF="origin/master"
+LOCAL_LAST_SYNC_FILE="$SCRIPT_DIR/.last_sync.local"
+REMOTE_NAME="${SYNC_REMOTE_NAME:-origin}"
+BASE_BRANCH="${SYNC_BASE_BRANCH:-master}"
+REMOTE_REF="$REMOTE_NAME/$BASE_BRANCH"
 
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -38,10 +63,14 @@ refresh_last_sync() {
   local now="$1"
 
   if $DRY_RUN; then
-    echo "  [dry-run] would update .last_sync to $now"
+    echo "  [dry-run] would update .last_sync.local to $now"
   else
-    echo "$now" > "$SCRIPT_DIR/.last_sync"
+    echo "$now" > "$LOCAL_LAST_SYNC_FILE"
   fi
+}
+
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
 }
 
 abort_sync() {
@@ -74,7 +103,7 @@ print_managed_diff() {
   local range="$1"
   local diff_output
 
-  diff_output=$(git diff --name-status "$range" -- dotfiles packages.txt .last_sync 2>/dev/null || true)
+  diff_output=$(git diff --name-status "$range" -- dotfiles packages.txt 2>/dev/null || true)
   if [ -n "$diff_output" ]; then
     echo "$diff_output" | while IFS= read -r line; do
       note "managed change: $line"
@@ -94,6 +123,23 @@ ensure_clean_managed_files() {
   fi
 }
 
+ensure_clean_branch_context() {
+  local current_branch extra_dirty
+
+  current_branch=$(git branch --show-current)
+  if [ "$current_branch" != "$BASE_BRANCH" ]; then
+    abort_sync "sync.sh must start from the local $BASE_BRANCH branch so it can create a fresh sync branch."
+  fi
+
+  extra_dirty=$(git status --porcelain --untracked-files=all -- . ':(exclude)dotfiles' ':(exclude)packages.txt' ':(exclude).last_sync.local' ':(exclude)sync.log' ':(exclude).codex' 2>/dev/null || true)
+  if [ -n "$extra_dirty" ]; then
+    echo "$extra_dirty" | while IFS= read -r line; do
+      note "local worktree change pending: $line"
+    done
+    abort_sync "Worktree must be clean before sync creates a branch. Commit or stash unrelated changes first."
+  fi
+}
+
 fetch_remote_state() {
   if git fetch --quiet origin master; then
     info "Fetched latest remote state"
@@ -109,23 +155,97 @@ validate_branch_state() {
   remote_head=$(git rev-parse "$REMOTE_REF")
   merge_base=$(git merge-base HEAD "$REMOTE_REF")
 
-  if [ "$local_head" = "$remote_head" ]; then
-    info "Local branch matches $REMOTE_REF"
-    return
-  fi
-
-  if [ "$local_head" = "$merge_base" ]; then
+  if [ "$local_head" = "$merge_base" ] && [ "$local_head" != "$remote_head" ]; then
     print_managed_diff "HEAD..$REMOTE_REF"
-    abort_sync "Local branch is behind $REMOTE_REF. Pull the remote changes before syncing."
+    abort_sync "Local $BASE_BRANCH is behind $REMOTE_REF. Pull the remote changes before syncing."
   fi
 
-  if [ "$remote_head" = "$merge_base" ]; then
-    info "Local branch is ahead of $REMOTE_REF"
+  if [ "$remote_head" = "$merge_base" ] && [ "$local_head" != "$remote_head" ]; then
+    abort_sync "Local $BASE_BRANCH is ahead of $REMOTE_REF. Rebase or reconcile it before syncing."
+  fi
+
+  if [ "$local_head" = "$remote_head" ]; then
+    info "Local $BASE_BRANCH matches $REMOTE_REF"
     return
   fi
 
   print_managed_diff "$merge_base..$REMOTE_REF"
-  abort_sync "Local branch has diverged from $REMOTE_REF. Reconcile the branch before syncing."
+  abort_sync "Local $BASE_BRANCH has diverged from $REMOTE_REF. Reconcile the branch before syncing."
+}
+
+make_sync_branch_name() {
+  local host_slug stamp
+  host_slug=$(slugify "$(hostname -s 2>/dev/null || hostname)")
+  stamp=$(date '+%Y%m%d-%H%M%S')
+
+  if [ -n "$BRANCH_NAME" ]; then
+    echo "$BRANCH_NAME"
+  else
+    echo "sync/${host_slug}-${stamp}"
+  fi
+}
+
+create_sync_branch() {
+  local branch="$1"
+
+  if $DRY_RUN; then
+    echo "  [dry-run] would create branch $branch"
+  else
+    git switch -c "$branch"
+    info "Created branch $branch"
+  fi
+}
+
+push_sync_branch() {
+  local branch="$1"
+
+  if $DRY_RUN; then
+    echo "  [dry-run] would push branch $branch to $REMOTE_NAME"
+  else
+    git push -u "$REMOTE_NAME" "$branch"
+    info "Pushed branch $branch"
+  fi
+}
+
+open_pull_request() {
+  local branch="$1"
+  local title="$2"
+  local body
+
+  if ! $OPEN_PR; then
+    note "PR creation disabled by --no-pr"
+    return
+  fi
+
+  if ! command -v gh &>/dev/null; then
+    note "gh not installed — skipping PR creation"
+    return
+  fi
+
+  if ! gh auth status &>/dev/null 2>&1; then
+    note "gh is not authenticated — skipping PR creation"
+    return
+  fi
+
+  body=$(cat <<EOF
+## Summary
+
+- sync dotfiles snapshot
+- sync package snapshot
+
+## Notes
+
+- generated from environment: $(hostname -s 2>/dev/null || hostname)
+- review package and dotfile drift before merge
+EOF
+)
+
+  if $DRY_RUN; then
+    echo "  [dry-run] would open PR from $branch to $BASE_BRANCH"
+  else
+    gh pr create --base "$BASE_BRANCH" --head "$branch" --title "$title" --body "$body"
+    info "Opened PR for $branch"
+  fi
 }
 
 echo ""
@@ -140,6 +260,7 @@ cd "$SCRIPT_DIR"
 step "Validating repo state"
 
 ensure_clean_managed_files
+ensure_clean_branch_context
 
 if git rev-parse --is-inside-work-tree &>/dev/null; then
   fetch_remote_state
@@ -215,38 +336,40 @@ else
 fi
 
 # ── 4. Commit and push if anything changed ────────────────────────────────────
-step "Pushing to GitHub"
+step "Creating branch and publishing review"
 
 SYNC_TS=$(date +%s)
+SYNC_BRANCH=$(make_sync_branch_name)
 
 if ! $DRY_RUN; then
   scan_for_secrets
 
   if [ "$CHANGED" = true ]; then
-    # Include the sync timestamp when there is a real snapshot update to publish.
+    create_sync_branch "$SYNC_BRANCH"
     refresh_last_sync "$SYNC_TS"
-    git add dotfiles/.zshrc dotfiles/.bashrc dotfiles/.gitconfig.template dotfiles/.npmrc.template packages.txt .last_sync 2>/dev/null || true
+    git add dotfiles/.zshrc dotfiles/.bashrc dotfiles/.gitconfig.template dotfiles/.npmrc.template packages.txt 2>/dev/null || true
   else
     git add dotfiles/.zshrc dotfiles/.bashrc dotfiles/.gitconfig.template dotfiles/.npmrc.template packages.txt 2>/dev/null || true
   fi
 
   if ! git diff --cached --quiet; then
-    COMMIT_MSG="chore: sync dotfiles and packages — $(date '+%Y-%m-%d')"
+    COMMIT_MSG="chore: sync environment snapshot — $(date '+%Y-%m-%d')"
     git commit -m "$COMMIT_MSG"
-    git push origin master
-    info "Pushed to GitHub"
-    log "Sync complete — changes pushed"
+    push_sync_branch "$SYNC_BRANCH"
+    open_pull_request "$SYNC_BRANCH" "$COMMIT_MSG"
+    log "Sync complete — branch pushed for review"
   else
     refresh_last_sync "$SYNC_TS"
     info "Nothing to commit — repo is up to date"
-    info "Refreshed local .last_sync without creating a commit"
+    info "Refreshed local .last_sync.local without creating a commit"
     log "Sync complete — no changes"
   fi
 else
   if [ "$CHANGED" = true ]; then
-    echo "  [dry-run] would update .last_sync, commit, and push detected changes"
+    create_sync_branch "$SYNC_BRANCH"
+    echo "  [dry-run] would update .last_sync.local, commit, push $SYNC_BRANCH, and open a PR"
   else
-    echo "  [dry-run] would refresh local .last_sync without creating a commit"
+    echo "  [dry-run] would refresh local .last_sync.local without creating a commit"
   fi
 fi
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,225 @@
+# Template Layout Rules
+
+These templates follow one explicit boundary:
+
+- Codex runtime capabilities are outside the project
+- Claude project capabilities are inside the project
+
+## Outside The Project
+
+Codex-managed runtime assets belong in the user environment, not in the repository:
+
+```text
+~/.codex/
+├── config.toml
+├── skills/
+└── plugins/
+
+~/.agents/
+└── plugins/
+    └── marketplace.json
+```
+
+## Copy-Paste Starter Layout
+
+```text
+EXTERNAL TO THE PROJECT
+
+~/.codex/
+├── config.toml
+├── skills/
+└── plugins/
+
+~/.agents/
+└── plugins/
+    └── marketplace.json
+
+PROJECT
+
+your-saas/
+├── AGENTS.md
+├── CLAUDE.md
+├── .mcp.json
+├── .codex/
+│   ├── config.toml.example
+│   ├── prompts/
+│   └── mcp/
+├── .claude/
+│   ├── skills/
+│   ├── agents/
+│   └── commands/
+├── ai/
+│   ├── context/
+│   ├── standards/
+│   ├── agents/
+│   ├── commands/
+│   ├── playbooks/
+│   └── mcp/
+├── apps/
+│   ├── web/
+│   ├── api/
+│   └── worker/
+├── packages/
+│   ├── ui/
+│   ├── database/
+│   └── config/
+├── infra/
+│   ├── docker/
+│   └── terraform/
+├── docs/
+│   ├── adr/
+│   ├── architecture/
+│   ├── product/
+│   ├── runbooks/
+│   └── evals/
+├── scripts/
+│   └── ai/
+├── tests/
+│   ├── e2e/
+│   ├── integration/
+│   └── contract/
+└── .github/
+    └── workflows/
+```
+
+## Inside The Project
+
+The project repository keeps:
+
+- `AGENTS.md` for Codex repo instructions
+- `CLAUDE.md` for Claude repo memory
+- `.claude/skills/` for Claude project-native reusable capabilities
+- `.claude/agents/` for Claude subagents
+- `.mcp.json` for Claude project MCP
+- `ai/` for shared context, standards, and playbooks both tools can read
+- optional `.codex/` examples for config snippets and prompt recipes
+
+This keeps the repo portable without pretending Codex skills and plugins are repo-installed assets.
+
+## Small Template Tree
+
+```text
+templates/saas-agent-template
+├── AGENTS.md
+├── CLAUDE.md
+├── .mcp.json
+├── .codex/
+│   ├── README.md
+│   ├── agents/
+│   ├── config.toml.example
+│   ├── mcp/
+│   └── prompts/
+├── .claude/
+│   ├── agents/
+│   ├── commands/
+│   └── skills/
+├── ai/
+│   ├── README.md
+│   ├── agents/
+│   ├── commands/
+│   ├── context/
+│   ├── mcp/
+│   ├── playbooks/
+│   └── standards/
+├── apps/
+│   ├── README.md
+│   ├── api/
+│   ├── web/
+│   └── worker/
+├── packages/
+│   ├── README.md
+│   ├── config/
+│   ├── database/
+│   └── ui/
+├── infra/
+│   ├── README.md
+│   ├── docker/
+│   └── terraform/
+├── docs/
+│   ├── README.md
+│   ├── adr/
+│   ├── architecture/
+│   ├── evals/
+│   ├── product/
+│   └── runbooks/
+├── scripts/
+│   └── ai/
+├── tests/
+│   ├── README.md
+│   ├── contract/
+│   ├── e2e/
+│   └── integration/
+└── .github/
+    └── workflows/
+```
+
+## Enterprise Template Tree
+
+```text
+templates/saas-agent-template-enterprise
+├── AGENTS.md
+├── CLAUDE.md
+├── .mcp.json
+├── .codex/
+│   ├── README.md
+│   ├── agents/
+│   ├── config.toml.example
+│   ├── mcp/
+│   └── prompts/
+├── .claude/
+│   ├── agents/
+│   ├── commands/
+│   └── skills/
+├── ai/
+│   ├── README.md
+│   ├── agents/
+│   ├── commands/
+│   ├── context/
+│   ├── mcp/
+│   └── standards/
+├── apps/
+│   ├── README.md
+│   ├── admin/
+│   ├── api/
+│   ├── gateway/
+│   ├── web/
+│   └── worker/
+├── packages/
+│   ├── README.md
+│   ├── analytics/
+│   ├── auth/
+│   ├── billing/
+│   ├── config/
+│   ├── database/
+│   ├── notifications/
+│   ├── sdk/
+│   └── ui/
+├── infra/
+│   ├── README.md
+│   ├── docker/
+│   ├── kubernetes/
+│   ├── monitoring/
+│   └── terraform/
+├── docs/
+│   ├── README.md
+│   ├── adr/
+│   ├── architecture/
+│   ├── compliance/
+│   ├── incident-response/
+│   ├── product/
+│   ├── runbooks/
+│   └── security/
+├── scripts/
+│   ├── ai/
+│   ├── ci/
+│   └── ops/
+├── tests/
+│   ├── README.md
+│   ├── contract/
+│   ├── e2e/
+│   ├── integration/
+│   ├── performance/
+│   └── security/
+└── .github/
+    └── workflows/
+```

--- a/templates/saas-agent-template-cli-focused/.claude/agents/backend-engineer.md
+++ b/templates/saas-agent-template-cli-focused/.claude/agents/backend-engineer.md
@@ -1,0 +1,1 @@
+Focus on backend changes, contracts, persistence, and integration tests.

--- a/templates/saas-agent-template-cli-focused/.claude/agents/frontend-engineer.md
+++ b/templates/saas-agent-template-cli-focused/.claude/agents/frontend-engineer.md
@@ -1,0 +1,1 @@
+Focus on user flows, UX states, accessibility, and end-to-end impact.

--- a/templates/saas-agent-template-cli-focused/.claude/agents/product-architect.md
+++ b/templates/saas-agent-template-cli-focused/.claude/agents/product-architect.md
@@ -1,0 +1,1 @@
+Focus on product scope, domain model, package boundaries, and ADR-worthy decisions.

--- a/templates/saas-agent-template-cli-focused/.claude/commands/plan.md
+++ b/templates/saas-agent-template-cli-focused/.claude/commands/plan.md
@@ -1,0 +1,1 @@
+Read `ai/project.md` and generate a task-specific implementation plan.

--- a/templates/saas-agent-template-cli-focused/.claude/commands/review.md
+++ b/templates/saas-agent-template-cli-focused/.claude/commands/review.md
@@ -1,0 +1,1 @@
+Review the current change for bugs, regressions, and missing tests.

--- a/templates/saas-agent-template-cli-focused/.claude/commands/ship.md
+++ b/templates/saas-agent-template-cli-focused/.claude/commands/ship.md
@@ -1,0 +1,1 @@
+Prepare a release-readiness checklist for the current change.

--- a/templates/saas-agent-template-cli-focused/.claude/skills/release-manager/SKILL.md
+++ b/templates/saas-agent-template-cli-focused/.claude/skills/release-manager/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: release-manager
+description: Use when preparing a deploy, release checklist, or production cutover.
+---
+
+# Release Manager
+
+Read `ai/project.md`, confirm release readiness, and identify missing rollout or rollback steps.

--- a/templates/saas-agent-template-cli-focused/.claude/skills/saas-architect/SKILL.md
+++ b/templates/saas-agent-template-cli-focused/.claude/skills/saas-architect/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: saas-architect
+description: Use when defining tenant boundaries, plans, permissions, billing concepts, or app boundaries.
+---
+
+# SaaS Architect
+
+Read `ai/project.md` and optimize for the smallest durable SaaS architecture.

--- a/templates/saas-agent-template-cli-focused/.codex/README.md
+++ b/templates/saas-agent-template-cli-focused/.codex/README.md
@@ -1,0 +1,9 @@
+# Codex Notes
+
+This repository keeps Codex guidance in:
+
+- `AGENTS.md`
+- `ai/`
+- `.codex/` for config examples and prompt notes
+
+Codex runtime skills and plugins stay outside the repo in the user environment.

--- a/templates/saas-agent-template-cli-focused/.codex/agents/backend-engineer.md
+++ b/templates/saas-agent-template-cli-focused/.codex/agents/backend-engineer.md
@@ -1,0 +1,1 @@
+Read `ai/project.md` and focus on backend changes, data boundaries, and tests.

--- a/templates/saas-agent-template-cli-focused/.codex/agents/frontend-engineer.md
+++ b/templates/saas-agent-template-cli-focused/.codex/agents/frontend-engineer.md
@@ -1,0 +1,1 @@
+Read `ai/project.md` and focus on user flows, UI states, and accessibility.

--- a/templates/saas-agent-template-cli-focused/.codex/agents/product-architect.md
+++ b/templates/saas-agent-template-cli-focused/.codex/agents/product-architect.md
@@ -1,0 +1,1 @@
+Read `ai/project.md` and focus on scope, domain language, and app boundaries.

--- a/templates/saas-agent-template-cli-focused/.codex/config.toml.example
+++ b/templates/saas-agent-template-cli-focused/.codex/config.toml.example
@@ -1,0 +1,10 @@
+model = "gpt-5-codex"
+
+[profiles.default]
+model = "gpt-5-codex"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]

--- a/templates/saas-agent-template-cli-focused/.codex/mcp/README.md
+++ b/templates/saas-agent-template-cli-focused/.codex/mcp/README.md
@@ -1,0 +1,3 @@
+# Codex MCP Notes
+
+Keep Codex MCP examples here for copy-paste into user configuration.

--- a/templates/saas-agent-template-cli-focused/.codex/prompts/plan.md
+++ b/templates/saas-agent-template-cli-focused/.codex/prompts/plan.md
@@ -1,0 +1,1 @@
+Read `ai/project.md` and produce a concise implementation plan.

--- a/templates/saas-agent-template-cli-focused/.codex/prompts/review.md
+++ b/templates/saas-agent-template-cli-focused/.codex/prompts/review.md
@@ -1,0 +1,1 @@
+Review the current change for regressions, risk, and missing tests.

--- a/templates/saas-agent-template-cli-focused/.codex/prompts/ship.md
+++ b/templates/saas-agent-template-cli-focused/.codex/prompts/ship.md
@@ -1,0 +1,1 @@
+Prepare a release-readiness summary with tests, config, and rollback notes.

--- a/templates/saas-agent-template-cli-focused/.mcp.json
+++ b/templates/saas-agent-template-cli-focused/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "."
+      ]
+    }
+  }
+}

--- a/templates/saas-agent-template-cli-focused/AGENTS.md
+++ b/templates/saas-agent-template-cli-focused/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Operating Guide
+
+Read `ai/project.md` first, then follow the repo structure and update docs when behavior changes.
+
+Codex runtime skills and plugins are external to this repository. Use this file plus the shared `ai/` docs as the in-repo operating surface.

--- a/templates/saas-agent-template-cli-focused/CLAUDE.md
+++ b/templates/saas-agent-template-cli-focused/CLAUDE.md
@@ -1,0 +1,10 @@
+# Claude Code Guide
+
+Use this file as the Claude Code entrypoint.
+
+## Start Here
+
+1. Read `ai/project.md`
+2. Read `.claude/skills/` when a reusable capability matches the task
+3. Read `.claude/agents/` when the task is specialist work
+4. Use `.claude/commands/` for lightweight slash-command prompts

--- a/templates/saas-agent-template-cli-focused/README.md
+++ b/templates/saas-agent-template-cli-focused/README.md
@@ -1,0 +1,34 @@
+# SaaS Agent Template: CLI Focused
+
+This variant keeps the SaaS repo skeleton shallow and expands only the AI-facing folders for Claude Code and Codex CLI.
+
+Use it when you want:
+
+- full project-native Claude structure
+- repo-visible Codex notes and prompt scaffolding
+- minimal noise in app, package, infra, and docs folders
+
+## Layout
+
+```text
+templates/saas-agent-template-cli-focused
+├── AGENTS.md
+├── CLAUDE.md
+├── .mcp.json
+├── .codex/
+├── .claude/
+├── ai/
+├── apps/
+├── packages/
+├── infra/
+├── docs/
+├── scripts/
+├── tests/
+└── .github/
+```
+
+## Rule
+
+- Codex runtime skills and plugins stay outside the repo
+- Claude project skills and agents stay inside the repo
+- shared project context lives in `ai/`

--- a/templates/saas-agent-template-cli-focused/ai/project.md
+++ b/templates/saas-agent-template-cli-focused/ai/project.md
@@ -1,0 +1,3 @@
+# Project Context
+
+Replace this with your SaaS summary, target users, core workflows, and technical boundaries.

--- a/templates/saas-agent-template-cli-focused/apps/README.md
+++ b/templates/saas-agent-template-cli-focused/apps/README.md
@@ -1,0 +1,3 @@
+# Apps
+
+Keep deployable apps here.

--- a/templates/saas-agent-template-cli-focused/docs/README.md
+++ b/templates/saas-agent-template-cli-focused/docs/README.md
@@ -1,0 +1,3 @@
+# Docs
+
+Keep product, architecture, and runbook documentation here.

--- a/templates/saas-agent-template-cli-focused/infra/README.md
+++ b/templates/saas-agent-template-cli-focused/infra/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+Keep infrastructure definitions here.

--- a/templates/saas-agent-template-cli-focused/packages/README.md
+++ b/templates/saas-agent-template-cli-focused/packages/README.md
@@ -1,0 +1,3 @@
+# Packages
+
+Keep shared libraries here.

--- a/templates/saas-agent-template-cli-focused/tests/README.md
+++ b/templates/saas-agent-template-cli-focused/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Keep cross-app test suites here.

--- a/templates/saas-agent-template-enterprise/.claude/agents/platform-architect.md
+++ b/templates/saas-agent-template-enterprise/.claude/agents/platform-architect.md
@@ -1,0 +1,3 @@
+Read `ai/agents/platform-architect.md` first.
+
+In Claude Code, use this for multi-app or cross-package design work.

--- a/templates/saas-agent-template-enterprise/.claude/agents/release-manager.md
+++ b/templates/saas-agent-template-enterprise/.claude/agents/release-manager.md
@@ -1,0 +1,3 @@
+Read `ai/agents/release-manager.md` first.
+
+Use this for deploy planning, rollout steps, and rollback readiness.

--- a/templates/saas-agent-template-enterprise/.claude/agents/security-engineer.md
+++ b/templates/saas-agent-template-enterprise/.claude/agents/security-engineer.md
@@ -1,0 +1,3 @@
+Read `ai/agents/security-engineer.md` and `ai/standards/security.md` first.
+
+Use this when auth, permissions, tenant isolation, or admin flows are in scope.

--- a/templates/saas-agent-template-enterprise/.claude/commands/plan.md
+++ b/templates/saas-agent-template-enterprise/.claude/commands/plan.md
@@ -1,0 +1,1 @@
+Read `ai/commands/plan.md` and create an implementation plan with explicit risk areas.

--- a/templates/saas-agent-template-enterprise/.claude/commands/review.md
+++ b/templates/saas-agent-template-enterprise/.claude/commands/review.md
@@ -1,0 +1,1 @@
+Read `ai/commands/review.md` and perform an enterprise-grade review focused on bugs, security, and release risk.

--- a/templates/saas-agent-template-enterprise/.claude/commands/ship.md
+++ b/templates/saas-agent-template-enterprise/.claude/commands/ship.md
@@ -1,0 +1,1 @@
+Read `ai/commands/ship.md` and produce a release-readiness checklist with rollback notes.

--- a/templates/saas-agent-template-enterprise/.claude/skills/platform-architect/SKILL.md
+++ b/templates/saas-agent-template-enterprise/.claude/skills/platform-architect/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: platform-architect
+description: Use when a task affects multiple apps or packages, changes service boundaries, or needs an ADR-worthy architectural decision.
+---
+
+# Platform Architect
+
+Read:
+
+1. `ai/context/project.md`
+2. `ai/standards/engineering.md`
+3. related docs in `docs/architecture/` and `docs/adr/`
+
+Focus on stable interfaces, package boundaries, and rollout risk.

--- a/templates/saas-agent-template-enterprise/.claude/skills/release-governor/SKILL.md
+++ b/templates/saas-agent-template-enterprise/.claude/skills/release-governor/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: release-governor
+description: Use for risky releases involving migrations, auth, billing, or infrastructure changes.
+---
+
+# Release Governor
+
+Read:
+
+1. `ai/commands/ship.md`
+2. `docs/runbooks/`
+3. `docs/incident-response/`
+
+Produce a release-readiness view with rollout order, rollback path, and residual risk.

--- a/templates/saas-agent-template-enterprise/.claude/skills/security-reviewer/SKILL.md
+++ b/templates/saas-agent-template-enterprise/.claude/skills/security-reviewer/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: security-reviewer
+description: Use when auth, permissions, tenant isolation, file upload, webhook, billing, or admin functionality is in scope.
+---
+
+# Security Reviewer
+
+Read:
+
+1. `ai/standards/security.md`
+2. relevant docs in `docs/security/`
+
+Focus on auth boundaries, privilege escalation paths, tenant isolation, and security test gaps.

--- a/templates/saas-agent-template-enterprise/.codex/README.md
+++ b/templates/saas-agent-template-enterprise/.codex/README.md
@@ -1,0 +1,9 @@
+# Codex Enterprise Notes
+
+Codex should rely on:
+
+- `AGENTS.md` for repo-wide rules
+- `ai/` for shared context and standards
+- user-managed Codex skills and plugins outside the repository
+
+Use `.codex/prompts/` only for optional human-authored prompt recipes. They are not the primary skill discovery path.

--- a/templates/saas-agent-template-enterprise/.codex/agents/platform-architect.md
+++ b/templates/saas-agent-template-enterprise/.codex/agents/platform-architect.md
@@ -1,0 +1,7 @@
+Use `ai/agents/platform-architect.md` as the role definition.
+
+Before design or implementation, read:
+
+1. `ai/context/project.md`
+2. `ai/standards/engineering.md`
+3. related ADRs and architecture docs

--- a/templates/saas-agent-template-enterprise/.codex/agents/security-engineer.md
+++ b/templates/saas-agent-template-enterprise/.codex/agents/security-engineer.md
@@ -1,0 +1,3 @@
+Use `ai/agents/security-engineer.md` and `ai/standards/security.md` as the role definition.
+
+Before implementation, inspect related docs in `docs/security/`.

--- a/templates/saas-agent-template-enterprise/.codex/config.toml.example
+++ b/templates/saas-agent-template-enterprise/.codex/config.toml.example
@@ -1,0 +1,19 @@
+model = "gpt-5-codex"
+
+[profiles.default]
+model = "gpt-5-codex"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+
+[mcp_servers.docs]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+env = { CONTEXT7_API_KEY = "${CONTEXT7_API_KEY}" }
+
+[mcp_servers.postgres]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "${DATABASE_URL}"]

--- a/templates/saas-agent-template-enterprise/.codex/mcp/README.md
+++ b/templates/saas-agent-template-enterprise/.codex/mcp/README.md
@@ -1,0 +1,3 @@
+# Codex MCP Notes
+
+Store approved MCP snippets here for copy-paste into your active Codex configuration.

--- a/templates/saas-agent-template-enterprise/.codex/prompts/plan.md
+++ b/templates/saas-agent-template-enterprise/.codex/prompts/plan.md
@@ -1,0 +1,1 @@
+Read `ai/commands/plan.md` and apply it to the current task.

--- a/templates/saas-agent-template-enterprise/.codex/prompts/review.md
+++ b/templates/saas-agent-template-enterprise/.codex/prompts/review.md
@@ -1,0 +1,1 @@
+Read `ai/commands/review.md` and review the current change.

--- a/templates/saas-agent-template-enterprise/.codex/prompts/ship.md
+++ b/templates/saas-agent-template-enterprise/.codex/prompts/ship.md
@@ -1,0 +1,1 @@
+Read `ai/commands/ship.md` and prepare a release-readiness summary.

--- a/templates/saas-agent-template-enterprise/.env.example
+++ b/templates/saas-agent-template-enterprise/.env.example
@@ -1,0 +1,31 @@
+# Core
+APP_NAME=enterprise-saas
+APP_ENV=development
+APP_URL=http://localhost:3000
+ADMIN_URL=http://localhost:3001
+API_URL=http://localhost:4000
+
+# Data
+DATABASE_URL=postgres://user:password@localhost:5432/enterprise_saas
+REDIS_URL=redis://localhost:6379
+
+# Auth
+AUTH_SECRET=replace-me
+OIDC_ISSUER=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+
+# Billing
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Notifications
+RESEND_API_KEY=
+
+# Observability
+SENTRY_DSN=
+
+# AI / MCP
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+CONTEXT7_API_KEY=

--- a/templates/saas-agent-template-enterprise/.github/workflows/README.md
+++ b/templates/saas-agent-template-enterprise/.github/workflows/README.md
@@ -1,0 +1,3 @@
+# CI Workflows
+
+Add workflows for lint, typecheck, tests, build, deploy guards, and release validation.

--- a/templates/saas-agent-template-enterprise/.gitignore
+++ b/templates/saas-agent-template-enterprise/.gitignore
@@ -1,0 +1,10 @@
+.env
+.env.local
+.env.*.local
+node_modules/
+.next/
+dist/
+build/
+coverage/
+.turbo/
+.DS_Store

--- a/templates/saas-agent-template-enterprise/.mcp.json
+++ b/templates/saas-agent-template-enterprise/.mcp.json
@@ -1,0 +1,30 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "."
+      ]
+    },
+    "docs": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    },
+    "postgres": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "${DATABASE_URL}"
+      ]
+    }
+  }
+}

--- a/templates/saas-agent-template-enterprise/AGENTS.md
+++ b/templates/saas-agent-template-enterprise/AGENTS.md
@@ -1,0 +1,28 @@
+# Enterprise Agent Operating Guide
+
+Read `ai/context/project.md` and `ai/standards/engineering.md` before changing code.
+
+## Operating Priorities
+
+1. Preserve tenant isolation, auth boundaries, and billing correctness.
+2. Keep app boundaries explicit across `apps/` and `packages/`.
+3. Update tests and docs alongside behavior changes.
+4. Record structural decisions in `docs/adr/`.
+5. Record security-sensitive changes in `docs/security/` when relevant.
+
+## Repo Model
+
+- `apps/` contains deployable surfaces.
+- `packages/` contains reusable platform capabilities.
+- `infra/` contains delivery and runtime infrastructure.
+- `docs/` contains product, architecture, operations, and governance material.
+- `ai/` contains the shared AI operating layer for both Codex and Claude.
+- Codex runtime-installed skills, when used, live outside the repo under `~/.codex/skills/`.
+- Codex runtime-installed plugins, when used, live outside the repo under `~/.codex/plugins/`.
+
+## Working Rules
+
+- Do not inline secrets or credentials.
+- Prefer adapters around external providers.
+- Keep policy, auth, and billing logic centralized in dedicated packages.
+- Treat migrations and permissions changes as high-risk work.

--- a/templates/saas-agent-template-enterprise/CLAUDE.md
+++ b/templates/saas-agent-template-enterprise/CLAUDE.md
@@ -1,0 +1,19 @@
+# Claude Code Enterprise Guide
+
+This repo is organized for multi-surface SaaS development.
+
+## Start Sequence
+
+1. Read `ai/context/project.md`.
+2. Read `ai/standards/engineering.md`.
+3. Read `ai/standards/security.md` for auth, tenant, and data handling rules.
+4. Load a matching role from `.claude/agents/` when the task is specialized.
+
+## Claude-Specific Files
+
+- `.claude/agents/`: Claude subagents
+- `.claude/skills/`: Claude project skills and reusable slash-invokable capabilities
+- `.claude/commands/`: optional legacy command files
+- `.mcp.json`: Claude project MCP definitions
+
+Prefer `.claude/skills/` over `.claude/commands/` for anything non-trivial. Keep the shared layer in `ai/` as the source material those skills and agents reference.

--- a/templates/saas-agent-template-enterprise/README.md
+++ b/templates/saas-agent-template-enterprise/README.md
@@ -1,0 +1,106 @@
+# Enterprise SaaS Agent Template
+
+This is the heavier version of the starter for multi-team SaaS products that need stronger separation between product apps, platform services, compliance artifacts, and agent workflows.
+
+## When To Use This Version
+
+Use this template when you expect:
+
+- multiple frontend surfaces such as customer app and admin app
+- a dedicated API and background worker layer
+- shared platform packages for auth, billing, analytics, notifications, and SDKs
+- formal runbooks, ADRs, security notes, and compliance documentation
+- specialized agents for architecture, platform, release, and security work
+
+If the product is still small, this version is too much structure. Use the lighter template instead.
+
+## Layout
+
+```text
+saas-agent-template-enterprise/
+├── AGENTS.md
+├── CLAUDE.md
+├── .mcp.json
+├── .codex/
+├── .claude/
+├── ai/
+├── apps/
+├── packages/
+├── infra/
+├── docs/
+├── scripts/
+├── tests/
+└── .github/
+```
+
+## Design Rule
+
+`ai/` is still the shared source of truth. Claude gets project-native folders in `.claude/`. Codex is documented by the repo but its installed skills and plugins stay outside the project.
+
+## Tool Boundary
+
+This template is intentionally split between shared docs and project-native Claude folders.
+
+- Codex repo rules: `AGENTS.md`
+- Codex user skills: `~/.codex/skills/<skill>/SKILL.md`
+- Codex user plugins: `~/.codex/plugins/<plugin>/`
+- Claude project memory: `CLAUDE.md`
+- Claude project skills: `.claude/skills/<skill>/SKILL.md`
+- Claude project subagents: `.claude/agents/*.md`
+- Claude project MCP: `.mcp.json`
+
+`ai/` is not a native skill-discovery location for either tool. It exists to hold shared context and standards that both tools can read.
+
+## Enterprise Boundaries
+
+- `apps/web`: customer-facing app
+- `apps/admin`: internal operations and support app
+- `apps/api`: core backend API
+- `apps/gateway`: edge or BFF layer when needed
+- `apps/worker`: async processing and integrations
+- `packages/auth`: identity and permission logic
+- `packages/billing`: plans, invoicing, subscriptions
+- `packages/analytics`: event contracts and metric helpers
+- `packages/notifications`: email, SMS, and workflow messaging
+- `packages/sdk`: typed API clients for internal and external consumers
+- `infra/kubernetes`: deployment manifests or Helm charts
+- `infra/monitoring`: dashboards, alerts, and observability config
+- `docs/security`: threat models, control notes, and exception records
+- `docs/compliance`: audit evidence index, policy references, and controls mapping
+- `docs/incident-response`: incident templates and playbooks
+
+## Enterprise Agent Model
+
+- shared rules in `AGENTS.md`
+- shared project context in `ai/context/`
+- shared engineering and security standards in `ai/standards/`
+- shared role definitions in `ai/agents/`
+- Claude-ready wrappers in `.claude/`
+- optional Codex notes in `.codex/`
+
+## Codex Reality Check
+
+Codex is outside project scope in this layout.
+
+- User-installed marketplace skills generally install outside the repo, typically under `~/.codex/skills`
+- User-installed plugins generally install under `~/.codex/plugins` and may also be listed in `~/.agents/plugins/marketplace.json`
+- The project should only provide Codex instructions and context through `AGENTS.md`, `ai/`, and optional `.codex/` examples
+
+If you need reusable in-repo capability definitions, prefer Claude project skills in `.claude/skills/` or shared docs in `ai/`.
+
+## Claude Reality Check
+
+Claude still supports `.claude/commands/`, but current docs recommend skills because they support supporting files and are automatically discoverable.
+
+- Prefer `.claude/skills/` for reusable project capabilities
+- Use `.claude/agents/` for specialist subagents
+- Keep `.claude/commands/` only for simple legacy-style prompts if you really need explicit slash-command files
+
+## First Setup
+
+1. Replace placeholders in `ai/context/project.md`.
+2. Remove apps and packages you do not need.
+3. Fill in `docs/security/` and `docs/compliance/` only if they are real requirements.
+4. Register approved MCP servers in `ai/mcp/catalog.md`.
+5. Put repo-native Claude skills in `.claude/skills/`.
+6. Copy MCP snippets from `.mcp.json` and `.codex/config.toml.example` into your actual tool configuration as needed.

--- a/templates/saas-agent-template-enterprise/ai/README.md
+++ b/templates/saas-agent-template-enterprise/ai/README.md
@@ -1,0 +1,14 @@
+# Shared Enterprise AI Layer
+
+Use this directory as the canonical knowledge base for both Codex CLI and Claude Code.
+
+- `context/`: business, system, and operating context
+- `standards/`: engineering and security rules
+- `agents/`: vendor-neutral role definitions
+- `commands/`: reusable playbooks
+- `mcp/`: approved MCP inventory and risk notes
+
+Native skill discovery happens elsewhere:
+
+- Codex user skills: `~/.codex/skills/`
+- Claude project skills: `.claude/skills/`

--- a/templates/saas-agent-template-enterprise/ai/agents/data-engineer.md
+++ b/templates/saas-agent-template-enterprise/ai/agents/data-engineer.md
@@ -1,0 +1,10 @@
+# Data Engineer
+
+Use for schema design, event contracts, analytics pipelines, and retention-sensitive data handling.
+
+Focus:
+
+- schema evolution
+- migration safety
+- analytics event consistency
+- operational reporting boundaries

--- a/templates/saas-agent-template-enterprise/ai/agents/platform-architect.md
+++ b/templates/saas-agent-template-enterprise/ai/agents/platform-architect.md
@@ -1,0 +1,11 @@
+# Platform Architect
+
+Use for cross-app boundaries, shared package design, integration patterns, and delivery topology.
+
+Focus:
+
+- service decomposition
+- package ownership
+- runtime boundaries
+- infrastructure interfaces
+- ADR-worthy decisions

--- a/templates/saas-agent-template-enterprise/ai/agents/release-manager.md
+++ b/templates/saas-agent-template-enterprise/ai/agents/release-manager.md
@@ -1,0 +1,10 @@
+# Release Manager
+
+Use for deployment planning, migration sequencing, rollback paths, change windows, and release communications.
+
+Focus:
+
+- rollout order
+- rollback safety
+- operator impact
+- runbook completeness

--- a/templates/saas-agent-template-enterprise/ai/agents/security-engineer.md
+++ b/templates/saas-agent-template-enterprise/ai/agents/security-engineer.md
@@ -1,0 +1,11 @@
+# Security Engineer
+
+Use for authentication, authorization, secrets handling, tenant isolation, webhook security, and threat modeling.
+
+Focus:
+
+- auth boundary review
+- privilege escalation paths
+- sensitive data flows
+- control gaps
+- security test coverage

--- a/templates/saas-agent-template-enterprise/ai/commands/plan.md
+++ b/templates/saas-agent-template-enterprise/ai/commands/plan.md
@@ -1,0 +1,9 @@
+# Enterprise Plan
+
+Produce:
+
+1. Goal and non-goals
+2. Affected apps, packages, infra, and docs
+3. Risk areas including auth, data, billing, and migrations
+4. Proposed implementation and rollout order
+5. Required tests, runbooks, and ADR updates

--- a/templates/saas-agent-template-enterprise/ai/commands/review.md
+++ b/templates/saas-agent-template-enterprise/ai/commands/review.md
@@ -1,0 +1,9 @@
+# Enterprise Review
+
+Review for:
+
+1. behavioral regressions
+2. security and tenant-isolation issues
+3. migration and rollout risk
+4. billing and permission mistakes
+5. missing tests, runbooks, or docs

--- a/templates/saas-agent-template-enterprise/ai/commands/ship.md
+++ b/templates/saas-agent-template-enterprise/ai/commands/ship.md
@@ -1,0 +1,10 @@
+# Enterprise Ship Checklist
+
+Verify:
+
+1. relevant tests passed
+2. migration order is documented
+3. env vars and secrets are documented
+4. dashboards and alerts are updated if needed
+5. rollback path is clear
+6. runbooks reflect operator impact

--- a/templates/saas-agent-template-enterprise/ai/context/project.md
+++ b/templates/saas-agent-template-enterprise/ai/context/project.md
@@ -1,0 +1,46 @@
+# Project Context
+
+## Product Summary
+
+Describe the product, customers, revenue model, and regulated or sensitive workflows here.
+
+## Operating Model
+
+- Customer segment:
+- Buying motion:
+- Contract model:
+- Data sensitivity:
+- Deployment model:
+
+## Domain Language
+
+- Workspace:
+- Organization:
+- User:
+- Role:
+- Subscription:
+- Invoice:
+- Event:
+
+## Core Surfaces
+
+- `apps/web`: customer product
+- `apps/admin`: internal admin and support tooling
+- `apps/api`: primary application backend
+- `apps/gateway`: edge aggregation or BFF layer
+- `apps/worker`: background jobs and provider syncs
+
+## Shared Platform Packages
+
+- `packages/auth`
+- `packages/billing`
+- `packages/analytics`
+- `packages/notifications`
+- `packages/database`
+- `packages/sdk`
+
+## Current Constraints
+
+- Prefer explicit ownership and package boundaries.
+- Avoid cross-app business logic duplication.
+- Treat tenant and billing assumptions as durable decisions.

--- a/templates/saas-agent-template-enterprise/ai/mcp/catalog.md
+++ b/templates/saas-agent-template-enterprise/ai/mcp/catalog.md
@@ -1,0 +1,13 @@
+# MCP Catalog
+
+Record approved MCP servers here.
+
+For each server capture:
+
+- Name
+- Purpose
+- Owner
+- Secrets required
+- Environments allowed
+- Read or write capability
+- Risk notes

--- a/templates/saas-agent-template-enterprise/ai/standards/engineering.md
+++ b/templates/saas-agent-template-enterprise/ai/standards/engineering.md
@@ -1,0 +1,21 @@
+# Engineering Standards
+
+## System Boundaries
+
+- Deployable systems live under `apps/`.
+- Shared platform logic lives under `packages/`.
+- Infrastructure definitions live under `infra/`.
+- Durable design decisions belong in `docs/adr/`.
+
+## Code Rules
+
+- Add or update tests for changed behavior.
+- Keep public contracts typed and explicit.
+- Centralize policy, auth, and billing logic.
+- Hide external provider details behind adapters.
+
+## Delivery Rules
+
+- Ship vertical slices with docs and tests.
+- Add runbook updates for operationally meaningful changes.
+- Document migrations and rollout ordering.

--- a/templates/saas-agent-template-enterprise/ai/standards/security.md
+++ b/templates/saas-agent-template-enterprise/ai/standards/security.md
@@ -1,0 +1,18 @@
+# Security Standards
+
+## High-Risk Areas
+
+- authentication and session handling
+- authorization and permissions
+- tenant isolation
+- billing and payment flows
+- admin actions and support impersonation
+- file upload and webhook ingestion
+
+## Rules
+
+- Never hardcode secrets.
+- Validate auth and authorization at system boundaries.
+- Keep privileged admin flows separate from end-user flows.
+- Record threat-relevant design changes in `docs/security/`.
+- Add security tests for auth, tenant, or input validation changes.

--- a/templates/saas-agent-template-enterprise/apps/README.md
+++ b/templates/saas-agent-template-enterprise/apps/README.md
@@ -1,0 +1,7 @@
+# Apps
+
+- `web/`: customer-facing product
+- `admin/`: internal support and operations UI
+- `api/`: application backend
+- `gateway/`: optional edge gateway or backend-for-frontend
+- `worker/`: asynchronous jobs and provider syncs

--- a/templates/saas-agent-template-enterprise/docs/README.md
+++ b/templates/saas-agent-template-enterprise/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+- `adr/`: architecture decisions
+- `architecture/`: system diagrams and integration notes
+- `product/`: requirements and flows
+- `runbooks/`: operator playbooks
+- `security/`: threat models and security notes
+- `compliance/`: controls and audit mappings
+- `incident-response/`: response templates and procedures

--- a/templates/saas-agent-template-enterprise/infra/README.md
+++ b/templates/saas-agent-template-enterprise/infra/README.md
@@ -1,0 +1,6 @@
+# Infrastructure
+
+- `docker/`: local and CI images
+- `terraform/`: cloud resources
+- `kubernetes/`: deployment manifests or Helm charts
+- `monitoring/`: dashboards, alerts, and telemetry config

--- a/templates/saas-agent-template-enterprise/packages/README.md
+++ b/templates/saas-agent-template-enterprise/packages/README.md
@@ -1,0 +1,10 @@
+# Packages
+
+- `ui/`: design system
+- `database/`: schema and migrations
+- `auth/`: identity, session, and permissions logic
+- `billing/`: pricing, subscription, and invoice logic
+- `analytics/`: event contracts and tracking helpers
+- `notifications/`: outbound messaging adapters
+- `sdk/`: shared typed clients
+- `config/`: lint, test, and TypeScript base configs

--- a/templates/saas-agent-template-enterprise/scripts/ai/README.md
+++ b/templates/saas-agent-template-enterprise/scripts/ai/README.md
@@ -1,0 +1,3 @@
+# AI Scripts
+
+Shared entrypoints for both CLIs belong here.

--- a/templates/saas-agent-template-enterprise/scripts/ci/README.md
+++ b/templates/saas-agent-template-enterprise/scripts/ci/README.md
@@ -1,0 +1,3 @@
+# CI Scripts
+
+Add repo-local lint, build, and test wrappers here.

--- a/templates/saas-agent-template-enterprise/scripts/ops/README.md
+++ b/templates/saas-agent-template-enterprise/scripts/ops/README.md
@@ -1,0 +1,3 @@
+# Ops Scripts
+
+Add operational helpers here for migrations, backfills, or smoke checks.

--- a/templates/saas-agent-template-enterprise/tests/README.md
+++ b/templates/saas-agent-template-enterprise/tests/README.md
@@ -1,0 +1,7 @@
+# Test Suites
+
+- `e2e/`: user journeys
+- `integration/`: adapter and service integration tests
+- `contract/`: service boundary and API compatibility tests
+- `performance/`: load and latency checks
+- `security/`: auth, permission, and abuse-path tests

--- a/templates/saas-agent-template/.claude/agents/backend-engineer.md
+++ b/templates/saas-agent-template/.claude/agents/backend-engineer.md
@@ -1,0 +1,3 @@
+Read `ai/agents/backend-engineer.md` first.
+
+When used in Claude Code, focus on robust service contracts, migrations, and test coverage.

--- a/templates/saas-agent-template/.claude/agents/frontend-engineer.md
+++ b/templates/saas-agent-template/.claude/agents/frontend-engineer.md
@@ -1,0 +1,3 @@
+Read `ai/agents/frontend-engineer.md` first.
+
+When used in Claude Code, keep UI changes aligned with product flows and accessibility requirements.

--- a/templates/saas-agent-template/.claude/agents/product-architect.md
+++ b/templates/saas-agent-template/.claude/agents/product-architect.md
@@ -1,0 +1,3 @@
+Read `ai/agents/product-architect.md` first.
+
+When used in Claude Code, prioritize repo structure, ADRs, and requirement clarity before implementation.

--- a/templates/saas-agent-template/.claude/commands/plan.md
+++ b/templates/saas-agent-template/.claude/commands/plan.md
@@ -1,0 +1,1 @@
+Read `ai/commands/plan.md` and generate a task-specific implementation plan for this repository.

--- a/templates/saas-agent-template/.claude/commands/review.md
+++ b/templates/saas-agent-template/.claude/commands/review.md
@@ -1,0 +1,1 @@
+Read `ai/commands/review.md` and perform a code review focused on bugs, risk, and missing tests.

--- a/templates/saas-agent-template/.claude/commands/ship.md
+++ b/templates/saas-agent-template/.claude/commands/ship.md
@@ -1,0 +1,1 @@
+Read `ai/commands/ship.md` and produce a release-readiness checklist for the current change set.

--- a/templates/saas-agent-template/.claude/skills/release-manager/SKILL.md
+++ b/templates/saas-agent-template/.claude/skills/release-manager/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: release-manager
+description: Use when preparing a deploy, release checklist, or production cutover for this SaaS project.
+---
+
+# Release Manager
+
+Read:
+
+1. `ai/commands/ship.md`
+2. `docs/runbooks/`
+
+Focus on release readiness, rollout order, rollback path, and missing operator steps.

--- a/templates/saas-agent-template/.claude/skills/saas-architect/SKILL.md
+++ b/templates/saas-agent-template/.claude/skills/saas-architect/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: saas-architect
+description: Use when defining tenant boundaries, plans, permissions, billing concepts, or app and package boundaries for this SaaS project.
+---
+
+# SaaS Architect
+
+Read:
+
+1. `ai/context/project.md`
+2. `ai/standards/engineering.md`
+
+Focus on durable app, package, and domain boundaries.

--- a/templates/saas-agent-template/.codex/README.md
+++ b/templates/saas-agent-template/.codex/README.md
@@ -1,0 +1,9 @@
+# Codex Notes
+
+Codex CLI should use:
+
+- `AGENTS.md` for repo-wide instructions
+- `ai/` for shared context and standards
+- external Codex skills and plugins managed in the user environment, not in this repo
+
+`.codex/` is only helper material for config snippets and human-authored prompt recipes.

--- a/templates/saas-agent-template/.codex/agents/backend-engineer.md
+++ b/templates/saas-agent-template/.codex/agents/backend-engineer.md
@@ -1,0 +1,7 @@
+Use `ai/agents/backend-engineer.md` as the role definition.
+
+Before implementation, read:
+
+1. `ai/context/project.md`
+2. `ai/standards/engineering.md`
+3. relevant docs in `docs/architecture/`

--- a/templates/saas-agent-template/.codex/agents/frontend-engineer.md
+++ b/templates/saas-agent-template/.codex/agents/frontend-engineer.md
@@ -1,0 +1,7 @@
+Use `ai/agents/frontend-engineer.md` as the role definition.
+
+Before implementation, read:
+
+1. `ai/context/project.md`
+2. `ai/standards/engineering.md`
+3. relevant docs in `docs/product/`

--- a/templates/saas-agent-template/.codex/config.toml.example
+++ b/templates/saas-agent-template/.codex/config.toml.example
@@ -1,0 +1,15 @@
+model = "gpt-5-codex"
+
+[profiles.default]
+model = "gpt-5-codex"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+
+[mcp_servers.docs]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+env = { CONTEXT7_API_KEY = "${CONTEXT7_API_KEY}" }

--- a/templates/saas-agent-template/.codex/mcp/README.md
+++ b/templates/saas-agent-template/.codex/mcp/README.md
@@ -1,0 +1,5 @@
+# Codex MCP Notes
+
+Keep approved MCP server snippets here, then copy the needed entries into your active Codex configuration.
+
+Do not commit real credentials.

--- a/templates/saas-agent-template/.codex/prompts/plan.md
+++ b/templates/saas-agent-template/.codex/prompts/plan.md
@@ -1,0 +1,1 @@
+Read `ai/commands/plan.md` and apply it to the current task.

--- a/templates/saas-agent-template/.codex/prompts/review.md
+++ b/templates/saas-agent-template/.codex/prompts/review.md
@@ -1,0 +1,1 @@
+Read `ai/commands/review.md` and review the current change.

--- a/templates/saas-agent-template/.codex/prompts/ship.md
+++ b/templates/saas-agent-template/.codex/prompts/ship.md
@@ -1,0 +1,1 @@
+Read `ai/commands/ship.md` and prepare a release-readiness summary.

--- a/templates/saas-agent-template/.env.example
+++ b/templates/saas-agent-template/.env.example
@@ -1,0 +1,15 @@
+# App
+APP_NAME=your-saas
+APP_ENV=development
+APP_URL=http://localhost:3000
+
+# Database
+DATABASE_URL=postgres://user:password@localhost:5432/your_saas
+
+# Auth
+AUTH_SECRET=replace-me
+
+# AI / MCP
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+CONTEXT7_API_KEY=

--- a/templates/saas-agent-template/.github/workflows/README.md
+++ b/templates/saas-agent-template/.github/workflows/README.md
@@ -1,0 +1,3 @@
+# CI Workflows
+
+Add CI definitions here for linting, tests, build, and deploy checks.

--- a/templates/saas-agent-template/.gitignore
+++ b/templates/saas-agent-template/.gitignore
@@ -1,0 +1,10 @@
+.env
+.env.local
+.env.*.local
+node_modules/
+.next/
+dist/
+build/
+coverage/
+.turbo/
+.DS_Store

--- a/templates/saas-agent-template/.mcp.json
+++ b/templates/saas-agent-template/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "."
+      ]
+    },
+    "docs": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}

--- a/templates/saas-agent-template/AGENTS.md
+++ b/templates/saas-agent-template/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent Operating Guide
+
+This repository is structured for autonomous coding agents.
+
+## Priority Order
+
+1. Read `ai/context/project.md` before making decisions.
+2. Follow `ai/standards/engineering.md` for implementation rules.
+3. Prefer changes inside `apps/` and `packages/` over ad hoc top-level files.
+4. Record major design decisions in `docs/adr/`.
+5. Add or update tests in `tests/` or the relevant app package before closing work.
+
+## Shared Conventions
+
+- Product requirements live in `docs/product/`.
+- Architecture and integration boundaries live in `docs/architecture/`.
+- Reusable execution playbooks live in `ai/commands/`.
+- Reusable role definitions live in `ai/agents/`.
+- Project-local workflow guides live in `ai/playbooks/`.
+- Codex runtime-installed skills, when used, live outside the repo under `~/.codex/skills/`.
+- Codex runtime-installed plugins, when used, live outside the repo under `~/.codex/plugins/`.
+- Operational scripts live in `scripts/ai/`.
+
+## Working Rules
+
+- Do not hardcode secrets.
+- Keep business logic out of UI-only packages.
+- Prefer small, reviewable changes.
+- When changing behavior, update docs and tests in the same pass.

--- a/templates/saas-agent-template/CLAUDE.md
+++ b/templates/saas-agent-template/CLAUDE.md
@@ -1,0 +1,29 @@
+# Claude Code Guide
+
+Use this file as the Claude Code repo entrypoint.
+
+## Start Here
+
+1. Read `ai/context/project.md`.
+2. Read `ai/standards/engineering.md`.
+3. If the task is role-specific, load the matching file in `.claude/agents/`.
+4. If the task maps to an existing reusable capability, prefer `.claude/skills/`.
+5. If the task maps to an existing playbook, use `.claude/commands/` or `ai/commands/`.
+
+## Repo Expectations
+
+- Main product surfaces live in `apps/`.
+- Shared libraries live in `packages/`.
+- Cross-cutting guidance lives in `ai/`.
+- Repo-local workflow guides live in `ai/playbooks/`.
+- Architecture records live in `docs/adr/`.
+- MCP servers for this repo are declared in `.mcp.json`.
+
+## Claude-Specific Structure
+
+- `.claude/agents/`: Claude subagents specialized by function.
+- `.claude/skills/`: Claude project skills.
+- `.claude/commands/`: optional slash command prompt files.
+- `.mcp.json`: Claude project MCP config.
+
+When a task does not require a Claude-specific wrapper, prefer the shared definitions under `ai/`. For reusable capabilities, prefer `.claude/skills/` over `.claude/commands/`.

--- a/templates/saas-agent-template/README.md
+++ b/templates/saas-agent-template/README.md
@@ -1,0 +1,75 @@
+# SaaS Agent Template
+
+Starter structure for a new SaaS project that is meant to work well with both Codex CLI and Claude Code.
+
+The template uses three layers:
+
+1. `ai/` is the shared source of truth for project context, standards, reusable agent roles, and project-local playbooks.
+2. `.claude/` contains Claude Code native assets such as project skills and subagents.
+3. `AGENTS.md` plus optional `.codex/` notes define how Codex should work with the repo, while Codex-installed skills and plugins stay outside the project.
+
+## Recommended Layout
+
+```text
+saas-agent-template/
+├── AGENTS.md
+├── CLAUDE.md
+├── .mcp.json
+├── .codex/
+├── .claude/
+├── ai/
+├── apps/
+├── packages/
+├── infra/
+├── docs/
+├── scripts/
+├── tests/
+└── .github/
+```
+
+## What Goes Where
+
+- `AGENTS.md`: shared repo-wide operating rules for coding agents.
+- `CLAUDE.md`: Claude Code specific workflow and repo entrypoint.
+- `.mcp.json`: project MCP config for Claude Code.
+- `.codex/config.toml.example`: example Codex MCP/profile config you can copy into your user config as needed.
+- `ai/context/`: product, business, and technical context that both tools should read.
+- `ai/standards/`: coding standards, architecture rules, release rules, and security boundaries.
+- `ai/agents/`: vendor-neutral role definitions that can be mirrored into tool-specific agent files.
+- `ai/commands/`: reusable task playbooks such as planning, code review, and release prep.
+- `ai/playbooks/`: repo-owned workflow docs and capability guides that both tools can read as project context.
+- `apps/`: deployable apps such as web, api, and workers.
+- `packages/`: shared libraries such as UI, SDK, DB, and tooling config.
+- `infra/`: Docker, Terraform, and environment provisioning.
+- `docs/`: ADRs, architecture notes, product docs, and runbooks.
+- `scripts/ai/`: shell wrappers for repetitive workflows that both CLIs can execute.
+- `tests/`: cross-app test suites.
+
+## Tooling Notes
+
+- Claude Code supports project memory through `CLAUDE.md`, project MCP via `.mcp.json`, project skills in `.claude/skills/`, and subagents in `.claude/agents/`.
+- Codex CLI should use `AGENTS.md` plus the shared docs in `ai/`.
+- `.codex/` is optional helper material for config snippets and human-authored prompt recipes. It is not the runtime install location for Codex skills or plugins.
+- `ai/playbooks/` is shared repo documentation. It is not a native install location for either Codex or Claude runtime skills.
+- Keep secrets out of repo config. Store placeholders in `.env.example` and read real values from environment variables.
+
+## Marketplace And Import Reality
+
+- Codex marketplace-installed skills usually end up outside the repo, typically under `~/.codex/skills`.
+- Codex marketplace-installed plugins usually live under `~/.codex/plugins` and may also be listed in `~/.agents/plugins/marketplace.json`.
+- Claude plugin-installed Skills come from the installed plugin, while project-native Claude Skills live in `.claude/skills/`.
+- In this template, Codex capabilities are intentionally outside repo scope. The project only documents Codex usage through `AGENTS.md`, shared docs in `ai/`, and optional `.codex/` examples.
+- If you need a reusable in-repo capability, prefer `.claude/skills/` for Claude and `ai/playbooks/` for shared documentation.
+
+## Suggested Docs To Add Early
+
+- `docs/evals/README.md`: AI eval strategy, scoring design, and ASCII workflow drafts for prompt, retrieval, and model regressions.
+
+## First Steps After Copying This Template
+
+1. Rename the project and replace all placeholder text.
+2. Fill in `ai/context/project.md` with product scope and domain language.
+3. Update `AGENTS.md` and `CLAUDE.md` with your team rules.
+4. Add or remove apps under `apps/` based on your product shape.
+5. Add Claude project skills in `.claude/skills/` when you need reusable in-repo capabilities.
+6. Configure MCP servers in `.mcp.json` and `.codex/config.toml.example`.

--- a/templates/saas-agent-template/ai/README.md
+++ b/templates/saas-agent-template/ai/README.md
@@ -1,0 +1,15 @@
+# Shared AI Layer
+
+This directory is the canonical source for shared project knowledge used by both Codex CLI and Claude Code.
+
+- `context/`: business and product context
+- `standards/`: engineering rules
+- `agents/`: role definitions
+- `commands/`: repeatable task playbooks
+- `playbooks/`: project-local workflow guides and capability notes
+- `mcp/`: MCP catalog and usage notes
+
+Native skill discovery happens elsewhere:
+
+- Codex user skills: `~/.codex/skills/`
+- Claude project skills: `.claude/skills/`

--- a/templates/saas-agent-template/ai/agents/backend-engineer.md
+++ b/templates/saas-agent-template/ai/agents/backend-engineer.md
@@ -1,0 +1,11 @@
+# Backend Engineer
+
+Use when working in `apps/api`, `apps/worker`, or `packages/database`.
+
+Focus:
+
+- service boundaries
+- data model integrity
+- background jobs
+- external integrations
+- contract and integration tests

--- a/templates/saas-agent-template/ai/agents/frontend-engineer.md
+++ b/templates/saas-agent-template/ai/agents/frontend-engineer.md
@@ -1,0 +1,11 @@
+# Frontend Engineer
+
+Use when working in `apps/web` or `packages/ui`.
+
+Focus:
+
+- user flows
+- page states and empty states
+- component contracts
+- accessibility
+- end-to-end coverage for primary journeys

--- a/templates/saas-agent-template/ai/agents/growth-analyst.md
+++ b/templates/saas-agent-template/ai/agents/growth-analyst.md
@@ -1,0 +1,10 @@
+# Growth Analyst
+
+Use when working on onboarding, conversion, retention, analytics, and experiment design.
+
+Focus:
+
+- activation metrics
+- funnel instrumentation
+- lifecycle messaging inputs
+- feature flag strategy

--- a/templates/saas-agent-template/ai/agents/product-architect.md
+++ b/templates/saas-agent-template/ai/agents/product-architect.md
@@ -1,0 +1,10 @@
+# Product Architect
+
+Use when defining scope, boundaries, domain language, and ADR-level decisions.
+
+Focus:
+
+- MVP cuts
+- package and app boundaries
+- tenant, auth, and billing model choices
+- docs alignment across `ai/context/` and `docs/`

--- a/templates/saas-agent-template/ai/commands/plan.md
+++ b/templates/saas-agent-template/ai/commands/plan.md
@@ -1,0 +1,9 @@
+# Plan Work
+
+When planning, produce:
+
+1. Goal and non-goals
+2. Affected apps and packages
+3. Risks and unknowns
+4. Proposed implementation order
+5. Required tests and docs updates

--- a/templates/saas-agent-template/ai/commands/review.md
+++ b/templates/saas-agent-template/ai/commands/review.md
@@ -1,0 +1,9 @@
+# Review Work
+
+Review for:
+
+1. Behavioral regressions
+2. Security and auth boundary mistakes
+3. Data model or migration risk
+4. Missing tests
+5. Missing docs or operator notes

--- a/templates/saas-agent-template/ai/commands/ship.md
+++ b/templates/saas-agent-template/ai/commands/ship.md
@@ -1,0 +1,9 @@
+# Ship Work
+
+Before shipping, verify:
+
+1. Tests relevant to changed code passed
+2. Config and env variables are documented
+3. User-visible changes are reflected in docs
+4. Migrations and rollback steps are clear
+5. Monitoring and runbook needs are captured

--- a/templates/saas-agent-template/ai/context/project.md
+++ b/templates/saas-agent-template/ai/context/project.md
@@ -1,0 +1,34 @@
+# Project Context
+
+## Product Summary
+
+Replace this section with a short description of your SaaS, target users, core workflows, and commercial model.
+
+## Business Model
+
+- Customer type:
+- Pricing model:
+- Primary activation event:
+- Primary retention metric:
+
+## Domain Language
+
+- Workspace:
+- Account:
+- Subscription:
+- Seat:
+- Billing cycle:
+
+## Core Systems
+
+- `apps/web`: customer-facing application
+- `apps/api`: primary backend API
+- `apps/worker`: async jobs and integrations
+- `packages/database`: schema and migrations
+- `packages/ui`: shared UI system
+
+## Current Priorities
+
+- Define MVP scope
+- Keep auth and billing boundaries explicit
+- Prefer boring infrastructure for the first release

--- a/templates/saas-agent-template/ai/mcp/catalog.md
+++ b/templates/saas-agent-template/ai/mcp/catalog.md
@@ -1,0 +1,13 @@
+# MCP Catalog
+
+Document each approved MCP server here before adding it to tool configs.
+
+Suggested template:
+
+- Name:
+- Purpose:
+- Transport:
+- Owner:
+- Required secrets:
+- Allowed environments:
+- Risk notes:

--- a/templates/saas-agent-template/ai/playbooks/release-manager.md
+++ b/templates/saas-agent-template/ai/playbooks/release-manager.md
@@ -1,0 +1,10 @@
+# Release Manager
+
+Use this playbook when preparing a deploy, release checklist, or production cutover.
+
+## Workflow
+
+1. Review `ai/commands/ship.md`.
+2. Confirm migrations, env vars, and monitoring changes.
+3. Update `docs/runbooks/` for operator impact.
+4. Summarize release risk and rollback path.

--- a/templates/saas-agent-template/ai/playbooks/saas-architect.md
+++ b/templates/saas-agent-template/ai/playbooks/saas-architect.md
@@ -1,0 +1,10 @@
+# SaaS Architect
+
+Use this playbook when defining tenant boundaries, billing concepts, permissions, subscription plans, or product packaging.
+
+## Workflow
+
+1. Read `ai/context/project.md`.
+2. Check existing decisions in `docs/adr/`.
+3. Propose the smallest durable model that can support the current product stage.
+4. Write down any irreversible decisions as a new ADR.

--- a/templates/saas-agent-template/ai/standards/engineering.md
+++ b/templates/saas-agent-template/ai/standards/engineering.md
@@ -1,0 +1,20 @@
+# Engineering Standards
+
+## Architecture
+
+- Keep deployable surfaces in `apps/`.
+- Keep reusable code in `packages/`.
+- Use `docs/adr/` for decisions that change interfaces, data models, or deployment shape.
+
+## Code Quality
+
+- Add tests for changed behavior.
+- Prefer explicit types at system boundaries.
+- Isolate external integrations behind adapters.
+- Keep configuration in env vars, never inline secrets.
+
+## Delivery
+
+- Ship vertical slices instead of broad unfinished scaffolding.
+- Update docs when setup, behavior, or operating assumptions change.
+- Use `scripts/ai/` for repetitive local workflows.

--- a/templates/saas-agent-template/apps/README.md
+++ b/templates/saas-agent-template/apps/README.md
@@ -1,0 +1,7 @@
+# Apps
+
+Deployable services live here.
+
+- `web/`: frontend app
+- `api/`: backend API
+- `worker/`: background jobs and scheduled tasks

--- a/templates/saas-agent-template/docs/README.md
+++ b/templates/saas-agent-template/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+- `adr/`: architecture decision records
+- `architecture/`: system maps and integration notes
+- `evals/`: AI evaluation strategy, datasets, scoring, and workflow diagrams
+- `product/`: product requirements and flows
+- `runbooks/`: operator and incident procedures

--- a/templates/saas-agent-template/docs/evals/README.md
+++ b/templates/saas-agent-template/docs/evals/README.md
@@ -1,0 +1,274 @@
+# Evals
+
+Practical guidance for adding evals to a SaaS product that uses Codex and Claude for application logic, prompt iteration, support workflows, or internal copilots.
+
+## Goal
+
+Evals are a regression system for AI behavior. They let the team answer:
+
+- Did the model follow policy?
+- Did retrieval bring the right context?
+- Did the tool chain produce the expected result?
+- Did a prompt or model change improve behavior or break it?
+
+The right approach is small, versioned, and tied to product risk. Do not start with a benchmark project. Start with the flows that can lose money, create support burden, or damage trust.
+
+## Core Principles
+
+- Test workflows, not model vibes.
+- Keep deterministic assertions separate from LLM grading.
+- Version prompts, rubrics, retrieval config, tools, and model IDs.
+- Add production failures back into the dataset every week.
+- Run a fast suite in PRs and a broader suite on a schedule.
+
+## Where Evals Fit
+
+```text
+Product workflow
+      |
+      v
+User input ---> Retrieval ---> Prompt/tool orchestration ---> Model output
+      |               |                    |                      |
+      |               |                    |                      |
+      +---------------+--------------------+----------------------+
+                              |
+                              v
+                            Evals
+                              |
+          +-------------------+-------------------+
+          |                                       |
+          v                                       v
+Deterministic checks                     Model-based grading
+schema, citations, cost,                correctness, tone,
+latency, tool calls                     policy, completeness
+```
+
+## Recommended Repo Shape
+
+```text
+docs/
+└── evals/
+    └── README.md
+
+tests/
+└── evals/
+    ├── datasets/
+    │   ├── support-replies.jsonl
+    │   ├── refunds.jsonl
+    │   └── sales-assistant.jsonl
+    ├── scorers/
+    │   ├── deterministic.ts
+    │   └── llm-grader.ts
+    ├── tasks/
+    │   ├── support-reply.ts
+    │   └── refund-agent.ts
+    ├── baselines/
+    │   └── latest.json
+    └── run.ts
+```
+
+## What To Evaluate First
+
+Start with 3 to 5 workflows:
+
+- support answer grounded in tenant data
+- refund or credit handling against policy
+- sales assistant accuracy on pricing and plan rules
+- ticket routing or classification
+- summarization of calls, emails, or incidents
+
+For each workflow, collect 20 to 50 cases before scaling further.
+
+## Dataset Format
+
+Each eval case should capture enough context to replay the task:
+
+```json
+{
+  "id": "refund-001",
+  "workflow": "refund-agent",
+  "input": "Customer asks for a refund after 45 days.",
+  "context": {
+    "tenant_tier": "pro",
+    "policy_version": "2026-03-15",
+    "retrieved_docs": ["refund-policy-v3"]
+  },
+  "expected": {
+    "outcome": "deny_refund",
+    "must_include": ["policy window"],
+    "must_not_include": ["invented exception"]
+  },
+  "tags": ["policy", "edge-case"]
+}
+```
+
+## Two-Layer Scoring
+
+### 1. Deterministic checks
+
+Use code for things that are objectively measurable:
+
+- output parses as JSON
+- required fields exist
+- tool calls happen in the expected order
+- citations are present
+- prohibited actions are absent
+- latency and token cost stay within budget
+
+### 2. Model-based grading
+
+Use an LLM judge only for qualitative questions:
+
+- was the answer factually grounded in provided context
+- did the tone match the workflow
+- did the assistant follow policy without over-refusing
+- did the summary preserve key facts and action items
+
+The grader should use a fixed rubric and return structured scores, not free-form opinions.
+
+## Codex and Claude Split
+
+Use each tool where it is strongest.
+
+### Codex
+
+- scaffolding the eval harness
+- writing loaders, scorers, and CI jobs
+- generating fixture templates and replay scripts
+- diffing prompt or tool changes against baselines
+
+### Claude
+
+- drafting rubrics for subjective grading
+- generating harder edge cases and adversarial prompts
+- serving as a second judge on ambiguous failures
+- reviewing prompt wording for policy and tone regressions
+
+## Workflow Drafts
+
+### Authoring workflow
+
+```text
+Prod incidents / support escalations / QA findings
+                      |
+                      v
+              Convert into eval cases
+                      |
+                      v
+            Add expected result or rubric
+                      |
+                      v
+              Store in versioned dataset
+                      |
+                      v
+             Run locally against baseline
+```
+
+### PR workflow
+
+```text
+Prompt change / tool change / retrieval change / model swap
+                      |
+                      v
+                Run smoke eval suite
+                      |
+          +-----------+------------+
+          |                        |
+          v                        v
+       Pass                     Fail
+          |                        |
+          v                        v
+      Merge PR            Inspect failing cases
+                                  |
+                                  v
+                       fix prompt, code, or rubric
+```
+
+### Weekly improvement workflow
+
+```text
+Production conversations
+          |
+          v
+Cluster bad outcomes by theme
+          |
+          v
+Select highest-cost failures
+          |
+          v
+Add new eval cases and rerun suite
+          |
+          v
+Update baseline after review
+```
+
+## CI Levels
+
+- `smoke`: 10 to 20 high-signal cases, runs on every PR
+- `core`: business-critical suite, runs on merge and before release
+- `full`: broader regression set, runs nightly or on schedule
+
+This keeps feedback fast while still catching slow-burn regressions.
+
+## Versioning Rules
+
+Every eval result should record:
+
+- workflow name
+- prompt version
+- model ID
+- retrieval or index version
+- tool schema version
+- rubric version
+- git commit SHA
+
+If these are missing, failures will be hard to compare over time.
+
+## Review Loop
+
+Use a simple decision rule for failures:
+
+```text
+Case failed
+   |
+   +--> bad expected result? -> fix dataset or rubric
+   |
+   +--> bad retrieval? ------> fix indexing or ranking
+   |
+   +--> bad orchestration? --> fix tools, guards, or code
+   |
+   +--> bad prompt/model? --> revise prompt or change model
+```
+
+## Minimal Adoption Plan
+
+Week 1:
+
+- choose 3 critical workflows
+- create 20 cases per workflow
+- implement deterministic scorers
+- add one LLM grader with a fixed rubric
+
+Week 2:
+
+- add PR smoke evals
+- capture cost and latency metrics
+- start turning production failures into cases
+
+Week 3:
+
+- add nightly full runs
+- compare model versions side by side
+- require baseline review before prompt releases
+
+## Common Mistakes
+
+- mixing expected output, policy, and grading logic in one place
+- using only LLM judging when exact assertions are available
+- skipping dataset versioning
+- evaluating generic prompts instead of product-specific workflows
+- collecting failures but never turning them into new cases
+
+## Bottom Line
+
+For a SaaS team, evals should behave like regression tests for business-critical AI workflows. Codex should own the harness and automation. Claude should help draft rubrics, generate edge cases, and act as a second reviewer where qualitative judgment is needed.

--- a/templates/saas-agent-template/infra/README.md
+++ b/templates/saas-agent-template/infra/README.md
@@ -1,0 +1,4 @@
+# Infrastructure
+
+- `docker/`: local containers and image definitions
+- `terraform/`: cloud infrastructure as code

--- a/templates/saas-agent-template/packages/README.md
+++ b/templates/saas-agent-template/packages/README.md
@@ -1,0 +1,7 @@
+# Packages
+
+Shared libraries and config live here.
+
+- `ui/`: design system and reusable UI components
+- `database/`: schema, ORM, and migrations
+- `config/`: lint, test, and TypeScript base config

--- a/templates/saas-agent-template/scripts/ai/README.md
+++ b/templates/saas-agent-template/scripts/ai/README.md
@@ -1,0 +1,9 @@
+# AI Scripts
+
+Place reusable shell entrypoints here for workflows both Codex and Claude can run.
+
+Examples:
+
+- `scripts/ai/bootstrap-dev.sh`
+- `scripts/ai/run-review.sh`
+- `scripts/ai/release-check.sh`

--- a/templates/saas-agent-template/tests/README.md
+++ b/templates/saas-agent-template/tests/README.md
@@ -1,0 +1,5 @@
+# Tests
+
+- `e2e/`: full user journeys
+- `integration/`: service and adapter integration tests
+- `contract/`: cross-service API contract tests


### PR DESCRIPTION
## Summary
- add reusable SaaS templates for Codex CLI and Claude Code
- add CLI-focused template variant
- change sync workflow to branch-and-PR based publishing
- move sync reminder timestamp to a local-only file to reduce cross-environment churn

## Notes
- excludes machine-local .last_sync changes
- keeps master for manual review and merge